### PR TITLE
[endpoints/marathon]

### DIFF
--- a/proxy/endpoints/marathon_endpoint.go
+++ b/proxy/endpoints/marathon_endpoint.go
@@ -191,9 +191,9 @@ func (r *MarathonEndpoint) HandleMarathonEvent(writer http.ResponseWriter, reque
 	} else {
 		switch event.EventType {
 		case "health_status_changed_event":
-			glog.V(5).Infof("Marathon application: %s health status has been altered, resyncing", event.AppID)
+			glog.V(4).Infof("Marathon application: %s health status has been altered, resyncing", event.AppID)
 		case "status_update_event":
-			glog.V(5).Infof("Marathon application: %s status update, resyncing endpoints", event.AppID)
+			glog.V(4).Infof("Marathon application: %s status update, resyncing endpoints", event.AppID)
 		default:
 			glog.V(10).Infof("Skipping the Marathon event, as it's not a status update, type: %s", event.EventType)
 			return


### PR DESCRIPTION
- filtering on a service port basis on the marathon application
- refusing to add endpoints which 'have' health checks, but have not been performed yet